### PR TITLE
Adding Linter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,11 +1,12 @@
-/mysql/*
-/helloworld/__pycache__/*
-/hempdb/__pycache__/*
-*/migrations/*
-*/__pycache__/*
+/mysql
+/helloworld/__pycache__
+/hempdb/__pycache__
+*/migrations
+*/__pycache__
 .DS_Store
 # Elastic Beanstalk Files
-.elasticbeanstalk/*
+.elasticbeanstalk
 !.elasticbeanstalk/*.cfg.yml
 !.elasticbeanstalk/*.global.yml
 .env
+.ruff_cache

--- a/README.md
+++ b/README.md
@@ -22,7 +22,10 @@ Note:
 
 **no need to restart docker, local code will be synced up with code in container. Just code, ctrl + s, see changes in browser**
 
-5. Open PR
+6. Lint with `ruff check .`
+6.a Fix with `ruff check . --fix`
+
+7. Open PR
 
 Make sure to add any new dependencies to requirements.txt
 

--- a/helloworld/admin.py
+++ b/helloworld/admin.py
@@ -1,3 +1,2 @@
-from django.contrib import admin
 
 # Register your models here.

--- a/helloworld/tests.py
+++ b/helloworld/tests.py
@@ -1,3 +1,2 @@
-from django.test import TestCase
 
 # Create your tests here.

--- a/helloworld/urls.py
+++ b/helloworld/urls.py
@@ -1,6 +1,6 @@
 from django.urls import path
 from . import views
-from .views import CompanyListView, CompanyCreateView
+from .views import CompanyCreateView
 
 urlpatterns = [
     path("", views.index, name="index"),

--- a/hempdb/urls.py
+++ b/hempdb/urls.py
@@ -1,6 +1,5 @@
 from django.contrib import admin
 from django.urls import include, path
-from django.views.generic.base import TemplateView
 """
 URL configuration for hempdb project.
 
@@ -17,8 +16,6 @@ Including another URLconf
     1. Import the include() function: from django.urls import include, path
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
-from django.contrib import admin
-from django.urls import path
 
 urlpatterns = [
     path("", include("helloworld.urls")),

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ mysqlclient==2.1.1
 python-dotenv==1.0.0
 django-bootstrap-v5==1.0.11
 djangorestframework==3.13.1
-# pandas==1.4.0
+ruff==0.1.14

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,74 @@
+# Exclude a variety of commonly ignored directories.
+exclude = [
+    ".bzr",
+    ".direnv",
+    ".eggs",
+    ".git",
+    ".git-rewrite",
+    ".hg",
+    ".ipynb_checkpoints",
+    ".mypy_cache",
+    ".nox",
+    ".pants.d",
+    ".pyenv",
+    ".pytest_cache",
+    ".pytype",
+    ".ruff_cache",
+    ".svn",
+    ".tox",
+    ".venv",
+    ".vscode",
+    "__pypackages__",
+    "_build",
+    "buck-out",
+    "build",
+    "dist",
+    "node_modules",
+    "site-packages",
+    "venv",
+]
+
+# Same as Black.
+line-length = 88
+indent-width = 4
+
+[lint]
+# Enable Pyflakes (`F`) and a subset of the pycodestyle (`E`)  codes by default.
+# Unlike Flake8, Ruff doesn't enable pycodestyle warnings (`W`) or
+# McCabe complexity (`C901`) by default.
+select = ["E4", "E7", "E9", "F"]
+ignore = []
+
+# Allow fix for all enabled rules (when `--fix`) is provided.
+fixable = ["ALL"]
+unfixable = []
+
+# Allow unused variables when underscore-prefixed.
+dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
+
+[format]
+# Like Black, use double quotes for strings.
+quote-style = "double"
+
+# Like Black, indent with spaces, rather than tabs.
+indent-style = "tab"
+
+# Like Black, respect magic trailing commas.
+skip-magic-trailing-comma = false
+
+# Like Black, automatically detect the appropriate line ending.
+line-ending = "auto"
+
+# Enable auto-formatting of code examples in docstrings. Markdown,
+# reStructuredText code/literal blocks and doctests are all supported.
+#
+# This is currently disabled by default, but it is planned for this
+# to be opt-out in the future.
+docstring-code-format = false
+
+# Set the line length limit used when formatting code snippets in
+# docstrings.
+#
+# This only has an effect when the `docstring-code-format` setting is
+# enabled.
+docstring-code-line-length = "dynamic"


### PR DESCRIPTION
Added the ruff python linter.

`ruff check .` to lint
`ruff check . --fix` to quick-fix

Documentation:
https://github.com/astral-sh/ruff

Config is open to suggestions, its currently based off of the existing code in the codebase.

Main notes:
- tabs instead of spaces (4 instead of 2)
- prefix unused vars with _
- no unused imports
- no duplicate imports
- double quotes
- trailing comma OK